### PR TITLE
initial implementation of npi19 sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -266,6 +266,7 @@ esphome/components/nextion/switch/* @senexcrenshaw
 esphome/components/nextion/text_sensor/* @senexcrenshaw
 esphome/components/nfc/* @jesserockz @kbx81
 esphome/components/noblex/* @AGalfra
+esphome/components/npi19/* @bakerkj
 esphome/components/number/* @esphome/core
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -32,8 +32,8 @@ void NPI19Component::dump_config() {
   ESP_LOGCONFIG(TAG, "NPI19:");
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);
-  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }
 
 float NPI19Component::get_setup_priority() const { return setup_priority::DATA; }
@@ -101,7 +101,7 @@ void NPI19Component::update() {
 
     float temperature = convert_temperature_(temperature_raw);
 
-    ESP_LOGD(TAG, "Got temperature=%.1f°C  pressure=%draw", temperature, pressure_raw);
+    ESP_LOGD(TAG, "Got pressure=%draw temperature=%.1f°C", pressure_raw, temperature);
 
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -32,7 +32,7 @@ void NPI19Component::dump_config() {
   ESP_LOGCONFIG(TAG, "NPI19:");
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);
-  LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
+  LOG_SENSOR("  ", "Raw Pressure", this->raw_pressure_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }
 
@@ -105,8 +105,8 @@ void NPI19Component::update() {
 
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
-    if (this->pressure_sensor_ != nullptr)
-      this->pressure_sensor_->publish_state(pressure_raw);
+    if (this->raw_pressure_sensor_ != nullptr)
+      this->raw_pressure_sensor_->publish_state(pressure_raw);
 
     this->status_clear_warning();
   });

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -54,10 +54,10 @@ i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressu
   }
 
   // extract top 6 bits of first byte and all bits of second byte for pressure
-  pressure_raw = ((response[0] & 0x3F) << 8) | (response[1] & 0xFF);
+  pressure_raw = ((response[0] & 0x3F) << 8) | response[1];
 
   // extract all bytes of 3rd byte and top 3 bits of fourth byte for temperature
-  temperature_raw = (((uint16_t) response[2] & 0xFF) << 3) | ((response[3] & 0xE0) >> 5);
+  temperature_raw = (response[2] << 3) | ((response[3] & 0xE0) >> 5);
 
   return r_err;
 }

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -1,0 +1,107 @@
+#include "npi19.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/hal.h"
+
+// https://www.amphenol-sensors.com/hubfs/I2C%20NPI-19%20product%20application%20Note.pdf
+// https://forum.arduino.cc/t/code-help-to-receive-data-from-i2c-vacuum-pressure-sensor/1025416/14
+
+namespace esphome {
+namespace npi19 {
+
+static const char *const TAG = "npi19";
+
+static const uint8_t READ_COMMAND = 0xAC;
+
+void NPI19Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up NPI19...");
+
+  uint16_t temperature_raw(0);
+  uint16_t pressure_raw(0);
+
+  // startup device delay
+  delay(10);
+
+  i2c::ErrorCode err = this->read_(temperature_raw, pressure_raw);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGCONFIG(TAG, "    I2C Communication Failed...");
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGCONFIG(TAG, "    Success...");
+}
+
+void NPI19Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "NPI19:");
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
+}
+
+float NPI19Component::get_setup_priority() const { return setup_priority::DATA; }
+
+i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressure_raw) {
+  i2c::ErrorCode w_err = write(&READ_COMMAND, sizeof(READ_COMMAND), true);
+  if (w_err != i2c::ERROR_OK) {
+    return w_err;
+  }
+
+  uint8_t response[4] = {0x00, 0x00, 0x00, 0x00};
+
+  // read 4 bytes from senesor
+  i2c::ErrorCode r_err = this->read(response, 4);
+
+  if (r_err != i2c::ERROR_OK) {
+    return r_err;
+  }
+
+  // extract top 6 bits of first byte and all bits of second byte for pressure
+  pressure_raw = ((response[0] & 0x3F) << 8) | (response[1] & 0xFF);
+
+  // extract all bytes of 3rd byte and top 3 bits of fourth byte for temperature
+  temperature_raw = (((uint16_t) response[2] & 0xFF) << 3) | ((response[3] & 0xE0) >> 5);
+
+  return r_err;
+}
+
+float NPI19Component::convert_temperature_(uint16_t temperature_raw) {
+  const float temperature_bits_span_ = 2048;
+  const float temperature_max_ = 150;
+  const float temperature_min_ = -50;
+  const float temperature_span_ = temperature_max_ - temperature_min_;
+
+  float temperature = (temperature_raw * temperature_span_ / temperature_bits_span_) + temperature_min_;
+
+  return temperature;
+}
+
+void NPI19Component::update() {
+  this->set_timeout(50, [this]() {
+    uint16_t temperature_raw(0);
+    uint16_t pressure_raw(0);
+
+    i2c::ErrorCode err = this->read_(temperature_raw, pressure_raw);
+
+    if (err != i2c::ERROR_OK) {
+      ESP_LOGW(TAG, "I2C Communication Failed");
+      this->status_set_warning();
+      return;
+    }
+
+    float temperature = convert_temperature_(temperature_raw);
+
+    ESP_LOGD(TAG, "Got temperature=%.1f°C  pressure=%draw", temperature, pressure_raw);
+
+    if (this->temperature_sensor_ != nullptr)
+      this->temperature_sensor_->publish_state(temperature);
+    if (this->pressure_sensor_ != nullptr)
+      this->pressure_sensor_->publish_state(pressure_raw);
+
+    this->status_clear_warning();
+  });
+}
+
+}  // namespace npi19
+}  // namespace esphome

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -13,12 +13,11 @@ static const uint8_t READ_COMMAND = 0xAC;
 void NPI19Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up NPI19...");
 
-  uint16_t temperature_raw(0);
-  uint16_t pressure_raw(0);
-
   // startup device delay
   delay(10);
 
+  uint16_t temperature_raw(0);
+  uint16_t pressure_raw(0);
   i2c::ErrorCode err = this->read_(temperature_raw, pressure_raw);
   if (err != i2c::ERROR_OK) {
     ESP_LOGCONFIG(TAG, "    I2C Communication Failed...");
@@ -40,14 +39,14 @@ void NPI19Component::dump_config() {
 float NPI19Component::get_setup_priority() const { return setup_priority::DATA; }
 
 i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressure_raw) {
+  // initiate data read from device
   i2c::ErrorCode w_err = write(&READ_COMMAND, sizeof(READ_COMMAND), true);
   if (w_err != i2c::ERROR_OK) {
     return w_err;
   }
 
-  uint8_t response[4] = {0x00, 0x00, 0x00, 0x00};
-
   // read 4 bytes from senesor
+  uint8_t response[4] = {0x00, 0x00, 0x00, 0x00};
   i2c::ErrorCode r_err = this->read(response, 4);
 
   if (r_err != i2c::ERROR_OK) {
@@ -70,9 +69,12 @@ float NPI19Component::convert_temperature_(uint16_t temperature_raw) {
    *
    * Tl is actually the upper 3 bits of the fourth data byte; the first 5 (LSBs) must be masked out.
    *
-   * Note that although the NPI-19 I2C Series has a temperature output, we don’t specify its accuracy on
-   * the published data sheet.  For this reason, the sensor should not be used as a calibrated temperature
-   * reading; it’s only intended for curve fitting data during compensation.
+   *
+   * The NPI-19 I2C has a temperature output, however the manufacturer does
+   * not specify its accuracy on the published datasheet. They indicate
+   * that the sensor should not be used as a calibrated temperature
+   * reading; it’s only intended for curve fitting data during
+   * compensation.
    */
   const float temperature_bits_span_ = 2048;
   const float temperature_max_ = 150;

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -3,9 +3,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/hal.h"
 
-// https://www.amphenol-sensors.com/hubfs/I2C%20NPI-19%20product%20application%20Note.pdf
-// https://forum.arduino.cc/t/code-help-to-receive-data-from-i2c-vacuum-pressure-sensor/1025416/14
-
 namespace esphome {
 namespace npi19 {
 

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -67,6 +67,16 @@ i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressu
 }
 
 float NPI19Component::convert_temperature_(uint16_t temperature_raw) {
+  /*
+   * Correspondance with Amphenol confirmed the appropriate equation for computing temperature is:
+   * T (°C) =(((((Th*8)+Tl)/2048)*200)-50), where Th is the high (third) byte and Tl is the low (fourth) byte.
+   *
+   * Tl is actually the upper 3 bits of the fourth data byte; the first 5 (LSBs) must be masked out.
+   *
+   * Note that although the NPI-19 I2C Series has a temperature output, we don’t specify its accuracy on
+   * the published data sheet.  For this reason, the sensor should not be used as a calibrated temperature
+   * reading; it’s only intended for curve fitting data during compensation.
+   */
   const float temperature_bits_span_ = 2048;
   const float temperature_max_ = 150;
   const float temperature_min_ = -50;

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -16,9 +16,9 @@ void NPI19Component::setup() {
   // startup device delay
   delay(10);
 
-  uint16_t temperature_raw(0);
-  uint16_t pressure_raw(0);
-  i2c::ErrorCode err = this->read_(temperature_raw, pressure_raw);
+  uint16_t raw_temperature(0);
+  uint16_t raw_pressure(0);
+  i2c::ErrorCode err = this->read_(raw_temperature, raw_pressure);
   if (err != i2c::ERROR_OK) {
     ESP_LOGCONFIG(TAG, "    I2C Communication Failed...");
     this->mark_failed();
@@ -38,7 +38,7 @@ void NPI19Component::dump_config() {
 
 float NPI19Component::get_setup_priority() const { return setup_priority::DATA; }
 
-i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressure_raw) {
+i2c::ErrorCode NPI19Component::read_(uint16_t &raw_temperature, uint16_t &raw_pressure) {
   // initiate data read from device
   i2c::ErrorCode w_err = write(&READ_COMMAND, sizeof(READ_COMMAND), true);
   if (w_err != i2c::ERROR_OK) {
@@ -54,15 +54,15 @@ i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressu
   }
 
   // extract top 6 bits of first byte and all bits of second byte for pressure
-  pressure_raw = ((response[0] & 0x3F) << 8) | response[1];
+  raw_pressure = ((response[0] & 0x3F) << 8) | response[1];
 
   // extract all bytes of 3rd byte and top 3 bits of fourth byte for temperature
-  temperature_raw = (response[2] << 3) | ((response[3] & 0xE0) >> 5);
+  raw_temperature = (response[2] << 3) | ((response[3] & 0xE0) >> 5);
 
   return i2c::ERROR_OK;
 }
 
-float NPI19Component::convert_temperature_(uint16_t temperature_raw) {
+float NPI19Component::convert_temperature_(uint16_t raw_temperature) {
   /*
    * Correspondance with Amphenol confirmed the appropriate equation for computing temperature is:
    * T (°C) =(((((Th*8)+Tl)/2048)*200)-50), where Th is the high (third) byte and Tl is the low (fourth) byte.
@@ -81,17 +81,17 @@ float NPI19Component::convert_temperature_(uint16_t temperature_raw) {
   const float temperature_min_ = -50;
   const float temperature_span_ = temperature_max_ - temperature_min_;
 
-  float temperature = (temperature_raw * temperature_span_ / temperature_bits_span_) + temperature_min_;
+  float temperature = (raw_temperature * temperature_span_ / temperature_bits_span_) + temperature_min_;
 
   return temperature;
 }
 
 void NPI19Component::update() {
   this->set_timeout(50, [this]() {
-    uint16_t temperature_raw(0);
-    uint16_t pressure_raw(0);
+    uint16_t raw_temperature(0);
+    uint16_t raw_pressure(0);
 
-    i2c::ErrorCode err = this->read_(temperature_raw, pressure_raw);
+    i2c::ErrorCode err = this->read_(raw_temperature, raw_pressure);
 
     if (err != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "I2C Communication Failed");
@@ -99,14 +99,14 @@ void NPI19Component::update() {
       return;
     }
 
-    float temperature = convert_temperature_(temperature_raw);
+    float temperature = convert_temperature_(raw_temperature);
 
-    ESP_LOGD(TAG, "Got pressure=%draw temperature=%.1f°C", pressure_raw, temperature);
+    ESP_LOGD(TAG, "Got pressure=%draw temperature=%.1f°C", raw_pressure, temperature);
 
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
     if (this->raw_pressure_sensor_ != nullptr)
-      this->raw_pressure_sensor_->publish_state(pressure_raw);
+      this->raw_pressure_sensor_->publish_state(raw_pressure);
 
     this->status_clear_warning();
   });

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -59,7 +59,7 @@ i2c::ErrorCode NPI19Component::read_(uint16_t &temperature_raw, uint16_t &pressu
   // extract all bytes of 3rd byte and top 3 bits of fourth byte for temperature
   temperature_raw = (response[2] << 3) | ((response[3] & 0xE0) >> 5);
 
-  return r_err;
+  return i2c::ERROR_OK;
 }
 
 float NPI19Component::convert_temperature_(uint16_t temperature_raw) {

--- a/esphome/components/npi19/npi19.h
+++ b/esphome/components/npi19/npi19.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace npi19 {
+
+/// This class implements support for the npi19 pressure and temperature i2c sensors.
+class NPI19Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
+
+  float get_setup_priority() const override;
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+
+ protected:
+  i2c::ErrorCode read_(uint16_t &temperature_raw, uint16_t &pressure_raw);
+  float convert_temperature_(uint16_t temperature_raw);
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
+};
+
+}  // namespace npi19
+}  // namespace esphome

--- a/esphome/components/npi19/npi19.h
+++ b/esphome/components/npi19/npi19.h
@@ -19,8 +19,8 @@ class NPI19Component : public PollingComponent, public i2c::I2CDevice {
   void update() override;
 
  protected:
-  i2c::ErrorCode read_(uint16_t &temperature_raw, uint16_t &pressure_raw);
-  float convert_temperature_(uint16_t temperature_raw);
+  i2c::ErrorCode read_(uint16_t &raw_temperature, uint16_t &raw_pressure);
+  float convert_temperature_(uint16_t raw_temperature);
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *raw_pressure_sensor_{nullptr};
 };

--- a/esphome/components/npi19/npi19.h
+++ b/esphome/components/npi19/npi19.h
@@ -11,7 +11,7 @@ namespace npi19 {
 class NPI19Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
-  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
+  void set_raw_pressure_sensor(sensor::Sensor *raw_pressure_sensor) { raw_pressure_sensor_ = raw_pressure_sensor; }
 
   float get_setup_priority() const override;
   void setup() override;
@@ -22,7 +22,7 @@ class NPI19Component : public PollingComponent, public i2c::I2CDevice {
   i2c::ErrorCode read_(uint16_t &temperature_raw, uint16_t &pressure_raw);
   float convert_temperature_(uint16_t temperature_raw);
   sensor::Sensor *temperature_sensor_{nullptr};
-  sensor::Sensor *pressure_sensor_{nullptr};
+  sensor::Sensor *raw_pressure_sensor_{nullptr};
 };
 
 }  // namespace npi19

--- a/esphome/components/npi19/sensor.py
+++ b/esphome/components/npi19/sensor.py
@@ -1,0 +1,54 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+
+from esphome.const import (
+    CONF_ID,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+)
+
+CODEOWNERS = ["@bakerkj"]
+DEPENDENCIES = ["i2c"]
+
+npi19_ns = cg.esphome_ns.namespace("npi19")
+
+NPI19Component = npi19_ns.class_("NPI19Component", cg.PollingComponent, i2c.I2CDevice)
+
+CONFIG_MULTI = True
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(NPI19Component),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+                accuracy_decimals=0, state_class=STATE_CLASS_MEASUREMENT
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x28))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature_sensor(sens))
+
+    if CONF_PRESSURE in config:
+        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+        cg.add(var.set_pressure_sensor(sens))

--- a/esphome/components/npi19/sensor.py
+++ b/esphome/components/npi19/sensor.py
@@ -4,7 +4,6 @@ from esphome.components import i2c, sensor
 
 from esphome.const import (
     CONF_ID,
-    CONF_PRESSURE,
     CONF_TEMPERATURE,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
@@ -13,12 +12,13 @@ from esphome.const import (
 
 CODEOWNERS = ["@bakerkj"]
 DEPENDENCIES = ["i2c"]
+CONFIG_MULTI = True
 
 npi19_ns = cg.esphome_ns.namespace("npi19")
 
 NPI19Component = npi19_ns.class_("NPI19Component", cg.PollingComponent, i2c.I2CDevice)
 
-CONFIG_MULTI = True
+CONF_RAW_PRESSURE = "raw_pressure"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+            cv.Optional(CONF_RAW_PRESSURE): sensor.sensor_schema(
                 accuracy_decimals=0, state_class=STATE_CLASS_MEASUREMENT
             ),
         }
@@ -49,6 +49,6 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_PRESSURE in config:
-        sens = await sensor.new_sensor(config[CONF_PRESSURE])
-        cg.add(var.set_pressure_sensor(sens))
+    if CONF_RAW_PRESSURE in config:
+        sens = await sensor.new_sensor(config[CONF_RAW_PRESSURE])
+        cg.add(var.set_raw_pressure_sensor(sens))

--- a/tests/components/npi19/common.yaml
+++ b/tests/components/npi19/common.yaml
@@ -12,5 +12,5 @@ sensor:
     temperature:
       name: water temperature
 
-    pressure:
+    raw_pressure:
       name: water pressure

--- a/tests/components/npi19/common.yaml
+++ b/tests/components/npi19/common.yaml
@@ -1,0 +1,16 @@
+i2c:
+  id: i2c_bus
+  scl: ${scl_pin}
+  sda: ${sda_pin}
+  frequency: 200kHz
+
+sensor:
+  - platform: npi19
+    update_interval: 1s
+    i2c_id: i2c_bus
+
+    temperature:
+      name: water temperature
+
+    pressure:
+      name: water pressure

--- a/tests/components/npi19/test.esp32-idf.yaml
+++ b/tests/components/npi19/test.esp32-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO22
+  sda_pin: GPIO21
+
+<<: !include common.yaml

--- a/tests/components/npi19/test.esp32-s3-idf.yaml
+++ b/tests/components/npi19/test.esp32-s3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO40
+  sda_pin: GPIO41
+
+<<: !include common.yaml

--- a/tests/components/npi19/test.esp32-s3.yaml
+++ b/tests/components/npi19/test.esp32-s3.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO40
+  sda_pin: GPIO41
+
+<<: !include common.yaml

--- a/tests/components/npi19/test.esp32.yaml
+++ b/tests/components/npi19/test.esp32.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO22
+  sda_pin: GPIO21
+
+<<: !include common.yaml

--- a/tests/components/npi19/test.esp8266.yaml
+++ b/tests/components/npi19/test.esp8266.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO05
+  sda_pin: GPIO04
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
i2c:
  id: i2c_bus
  scan: true
  sda: 13
  scl: 16
  frequency: 200kHz

sensor:
  - platform: npi19
    i2c_id: i2c_bus
    temperature:
      name: Temperature
    pressure:
      id: pressure_raw
      internal: true

  - platform: copy
    source_id: pressure_raw
    name: Pressure
    state_class: measurement
    device_class: pressure
    unit_of_measurement: psi
    filters:
      # for 5 psi sensor
      - calibrate_linear:
          - 1638 -> 0.5
          - 8192 -> 2.5
          - 14746 -> 4.5
    accuracy_decimals: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
